### PR TITLE
Add Bicep template for Log Analytics Workspace summary logs

### DIFF
--- a/management_governance/log-analytics-workspace-summary-log.bicep
+++ b/management_governance/log-analytics-workspace-summary-log.bicep
@@ -1,0 +1,39 @@
+@description('Name of the resource.')
+param name string
+@description('Name for the Log Analytics Workspace resource associated with the summary logs.')
+param logAnalyticsWorkspaceName string
+@description('Description of the summary logs.')
+param summaryDescription string
+@description('Kusto query for the summary logs.')
+param query string
+@description('The execution interval in minutes, and the lookback time range.')
+@allowed([
+  20
+  30
+  60
+  120
+  180
+  360
+  720
+  1440
+])
+param binSize int = 60
+@description('Destination table for the summary logs. Name must end with "_CL".')
+param destinationTable string
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource summaryLog 'Microsoft.OperationalInsights/workspaces/summaryLogs@2023-01-01-preview' = {
+  name: '${logAnalyticsWorkspace.name}/${name}'
+  properties: {
+    ruleType: 'User'
+    description: summaryDescription
+    ruleDefinition: {
+      query: query
+      binSize: binSize
+      destinationTable: destinationTable
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Bicep template for creating and managing summary logs in a Log Analytics Workspace. The main changes include the definition of resources for the Log Analytics Workspace summary logs and necessary configuration

### New Bicep Template for Summary Logs:

* Defined a resource for summary logs using the `Microsoft.OperationalInsights/workspaces/summaryLogs@2023-01-01-preview` API version, including properties for description, rule definition, query, bin size, and destination table as configurable parameters.

By default, the `ruleType` is hardcoded, set to `User` as defined by the [Create or update a summary rule documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/summary-rules?tabs=api#create-or-update-a-summary-rule) parameters table.