### PR TITLE
Add Phi-4 model deployment option for AI Foundry

### DIFF
--- a/ai_ml/models.json
+++ b/ai_ml/models.json
@@ -1,5 +1,6 @@
 {
   "serverless": {
+    "Phi-4": "azureml://registries/azureml/models/Phi-4",
     "Phi-35-mini-instruct": "azureml://registries/azureml/models/Phi-3.5-mini-instruct",
     "Phi-35-moe-instruct": "azureml://registries/azureml/models/Phi-3.5-MoE-instruct",
     "Phi-3-small-8k-instruct": "azureml://registries/azureml/models/Phi-3-small-8k-instruct",


### PR DESCRIPTION
This pull request includes an update to the `ai_ml/models.json` file. The change adds a new model, [`Phi-4`](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-phi-4?pivots=programming-language-python#a-model-deployment), to the serverless models list.

* [`ai_ml/models.json`](diffhunk://#diff-52efe6a313e49e0f32855365baf8f7846edfdb963c5a0243f64ca1067ae384b4R3): Added the `Phi-4` model to the serverless models list.