### PR TITLE
Add Phi-4 multimodal instruct model to models.json

### DIFF
--- a/ai_ml/models.json
+++ b/ai_ml/models.json
@@ -1,5 +1,6 @@
 {
   "serverless": {
+    "Phi-4-multimodal-instruct": "azureml://registries/azureml/models/Phi-4-multimodal-instruct",
     "Phi-4": "azureml://registries/azureml/models/Phi-4",
     "Phi-35-mini-instruct": "azureml://registries/azureml/models/Phi-3.5-mini-instruct",
     "Phi-35-moe-instruct": "azureml://registries/azureml/models/Phi-3.5-MoE-instruct",


### PR DESCRIPTION
This pull request adds a new model to the `ai_ml/models.json` file.

* Added the "Phi-4-multimodal-instruct" model to the `serverless` section in `ai_ml/models.json`.